### PR TITLE
Replace static logging with contextual loggers

### DIFF
--- a/backend/Veloci.Logic/API/Velocidrone.cs
+++ b/backend/Veloci.Logic/API/Velocidrone.cs
@@ -11,6 +11,8 @@ namespace Veloci.Logic.API;
 
 public class Velocidrone
 {
+    private static readonly ILogger _log = Log.ForContext<Velocidrone>();
+    
     private static HttpClient? _httpClient;
     private readonly string? _apiToken;
 
@@ -26,14 +28,14 @@ public class Velocidrone
 
     public async Task<ICollection<TrackTimeDto>> LeaderboardAsync(int trackId)
     {
-        Log.Debug("Requesting leaderboard for track {TrackId} from Velocidrone API", trackId);
+        _log.Debug("Requesting leaderboard for track {TrackId} from Velocidrone API", trackId);
         
         var payload = $"track_id={trackId}&sim_version=1.16&offset=0&count=1000&race_mode=6";
         var postData = $"post_data={Uri.EscapeDataString(payload)}";
 
         var response = await DoRequestAsync<LeaderboardDto>("api/leaderboard", HttpMethod.Post, postData);
         
-        Log.Information("Retrieved {ResultCount} results from Velocidrone API for track {TrackId}", 
+        _log.Information("Retrieved {ResultCount} results from Velocidrone API for track {TrackId}", 
             response.tracktimes.Count, trackId);
             
         return response.tracktimes;
@@ -42,7 +44,7 @@ public class Velocidrone
     private async Task<T> DoRequestAsync<T>(string uri, HttpMethod method, string? formData = null)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        Log.Debug("Making {Method} request to Velocidrone API endpoint: {Uri}", method, uri);
+        _log.Debug("Making {Method} request to Velocidrone API endpoint: {Uri}", method, uri);
         
         var request = new HttpRequestMessage(method, uri);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiToken);
@@ -50,7 +52,7 @@ public class Velocidrone
         if (formData is not null)
         {
             request.Content = new StringContent(formData, Encoding.UTF8, "application/x-www-form-urlencoded");
-            Log.Debug("Request includes form data: {FormDataLength} characters", formData.Length);
+            _log.Debug("Request includes form data: {FormDataLength} characters", formData.Length);
         }
 
         try
@@ -58,42 +60,42 @@ public class Velocidrone
             var response = await _httpClient.SendAsync(request);
             stopwatch.Stop();
 
-            Log.Debug("Velocidrone API responded with status {StatusCode} in {Duration}ms", 
+            _log.Debug("Velocidrone API responded with status {StatusCode} in {Duration}ms", 
                 response.StatusCode, stopwatch.ElapsedMilliseconds);
 
             if (response.IsSuccessStatusCode)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                Log.Debug("Received {ContentLength} characters in response body", content.Length);
+                _log.Debug("Received {ContentLength} characters in response body", content.Length);
                 
                 var data = JsonSerializer.Deserialize<T>(content);
 
                 if (data is not null)
                 {
-                    Log.Debug("Successfully deserialized Velocidrone API response to {ResponseType}", typeof(T).Name);
+                    _log.Debug("Successfully deserialized Velocidrone API response to {ResponseType}", typeof(T).Name);
                     return data;
                 }
 
-                Log.Error("Velocidrone API response deserialized as null for endpoint {Uri}", uri);
+                _log.Error("Velocidrone API response deserialized as null for endpoint {Uri}", uri);
                 throw new Exception("Response deserialized as null.");
             }
 
             var error = await response.Content.ReadAsStringAsync();
-            Log.Error("Velocidrone API request failed for {Uri}: {StatusCode} - {Error}", 
+            _log.Error("Velocidrone API request failed for {Uri}: {StatusCode} - {Error}", 
                 uri, response.StatusCode, error);
             throw new Exception($"Request failed: {response.StatusCode}, {error}");
         }
         catch (HttpRequestException ex)
         {
             stopwatch.Stop();
-            Log.Error(ex, "Network error during Velocidrone API request to {Uri} after {Duration}ms", 
+            _log.Error(ex, "Network error during Velocidrone API request to {Uri} after {Duration}ms", 
                 uri, stopwatch.ElapsedMilliseconds);
             throw;
         }
         catch (TaskCanceledException ex)
         {
             stopwatch.Stop();
-            Log.Error(ex, "Velocidrone API request to {Uri} timed out after {Duration}ms", 
+            _log.Error(ex, "Velocidrone API request to {Uri} timed out after {Duration}ms", 
                 uri, stopwatch.ElapsedMilliseconds);
             throw;
         }

--- a/backend/Veloci.Logic/Bot/Discord/DiscordBotHostedService.cs
+++ b/backend/Veloci.Logic/Bot/Discord/DiscordBotHostedService.cs
@@ -7,6 +7,8 @@ namespace Veloci.Logic.Bot;
 
 public class DiscordBotHostedService : IHostedService, IDisposable
 {
+    private static readonly ILogger _log = Log.ForContext<DiscordBotHostedService>();
+    
     private readonly DiscordBot _bot;
     private readonly IServiceScope _scope;
 
@@ -20,13 +22,13 @@ public class DiscordBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Information("Bot service DiscordBotHostedService starting...");
+            _log.Information("Bot service DiscordBotHostedService starting...");
             await _bot.StartAsync();
-            Log.Information("✅ Bot service DiscordBotHostedService started successfully");
+            _log.Information("✅ Bot service DiscordBotHostedService started successfully");
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Bot service DiscordBotHostedService encountered issues during startup");
+            _log.Error(ex, "Bot service DiscordBotHostedService encountered issues during startup");
             throw;
         }
     }
@@ -35,13 +37,13 @@ public class DiscordBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Information("Bot service DiscordBotHostedService stopping...");
+            _log.Information("Bot service DiscordBotHostedService stopping...");
             await _bot.Stop();
-            Log.Information("🛑 Bot service DiscordBotHostedService stopped gracefully");
+            _log.Information("🛑 Bot service DiscordBotHostedService stopped gracefully");
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Bot service DiscordBotHostedService encountered issues during shutdown");
+            _log.Error(ex, "Bot service DiscordBotHostedService encountered issues during shutdown");
             throw;
         }
     }
@@ -50,12 +52,12 @@ public class DiscordBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Debug("Disposing DiscordBotHostedService resources");
+            _log.Debug("Disposing DiscordBotHostedService resources");
             _scope.Dispose();
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error disposing DiscordBotHostedService resources");
+            _log.Error(ex, "Error disposing DiscordBotHostedService resources");
         }
     }
 }

--- a/backend/Veloci.Logic/Bot/Discord/DiscordMessageEventHandler.cs
+++ b/backend/Veloci.Logic/Bot/Discord/DiscordMessageEventHandler.cs
@@ -22,6 +22,8 @@ public class DiscordMessageEventHandler :
     INotificationHandler<DayStreakPotentialLose>,
     INotificationHandler<GotAchievements>
 {
+    private static readonly ILogger _log = Log.ForContext<DiscordMessageEventHandler>();
+    
     private readonly DiscordMessageComposer _messageComposer;
     private readonly IDiscordBot _discordBot;
     private readonly IRepository<Competition> _competitions;
@@ -163,7 +165,7 @@ public class DiscordMessageEventHandler :
         if (leaderboardMessageId is not null)
             return leaderboardMessageId;
 
-        Log.Error("Discord leaderboard message ID is null for competition {CompetitionId}", competition.Id);
+        _log.Error("Discord leaderboard message ID is null for competition {CompetitionId}", competition.Id);
         return null;
     }
 

--- a/backend/Veloci.Logic/Bot/Telegram/TelegramBot.cs
+++ b/backend/Veloci.Logic/Bot/Telegram/TelegramBot.cs
@@ -11,6 +11,8 @@ namespace Veloci.Logic.Bot.Telegram;
 
 public class TelegramBot
 {
+    private static readonly ILogger _log = Log.ForContext<TelegramBot>();
+    
     private readonly IServiceProvider _sp;
     private static string _botToken;
     private static string _channelId;
@@ -62,14 +64,14 @@ public class TelegramBot
     private static async Task HandleErrorAsync(ITelegramBotClient botClient, Exception exception,
         CancellationToken cancellationToken)
     {
-        Log.Error(exception, "Error in telegram bot");
+        _log.Error(exception, "Error in telegram bot");
     }
 
     public static async Task SendMessageAsync(string message)
     {
         try
         {
-            Log.Information("📲 Sending Telegram message to channel: {MessagePreview}...", 
+            _log.Information("📲 Sending Telegram message to channel: {MessagePreview}...", 
                 message.Length > 50 ? message.Substring(0, 50) + "..." : message);
             
             var result = await _client.SendTextMessageAsync(
@@ -77,11 +79,11 @@ public class TelegramBot
                 text: Isolate(message),
                 parseMode: ParseMode.MarkdownV2);
                 
-            Log.Debug("Telegram message sent successfully with {MessageLength} characters", message.Length);
+            _log.Debug("Telegram message sent successfully with {MessageLength} characters", message.Length);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to send a message '{Message}'", message);
+            _log.Error(ex, "Telegram. Failed to send a message '{Message}'", message);
         }
     }
 
@@ -89,7 +91,7 @@ public class TelegramBot
     {
         try
         {
-            Log.Information("Sending Telegram reply to message {MessageId} in chat {ChatId}: {MessagePreview}...", 
+            _log.Information("Sending Telegram reply to message {MessageId} in chat {ChatId}: {MessagePreview}...", 
                 messageId, chatId, message.Length > 50 ? message.Substring(0, 50) + "..." : message);
             
             var result = await _client.SendTextMessageAsync(
@@ -98,12 +100,12 @@ public class TelegramBot
                 parseMode: ParseMode.MarkdownV2,
                 text: Isolate(message));
 
-            Log.Debug("Telegram reply sent successfully as message {ReplyMessageId}", result.MessageId);
+            _log.Debug("Telegram reply sent successfully as message {ReplyMessageId}", result.MessageId);
             return result.MessageId;
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to send a message '{Message}'", message);
+            _log.Error(ex, "Telegram. Failed to send a message '{Message}'", message);
             return null;
         }
     }
@@ -120,7 +122,7 @@ public class TelegramBot
 
         try
         {
-            Log.Information("🖼️ Sending Telegram photo from URL {PhotoUrl} with caption: {Caption}", 
+            _log.Information("🖼️ Sending Telegram photo from URL {PhotoUrl} with caption: {Caption}", 
                 fileUrl, message ?? "(no caption)");
                 
             var result = await _client.SendPhotoAsync(
@@ -129,11 +131,11 @@ public class TelegramBot
                 photo: new InputFileUrl(fileUrl)
             );
             
-            Log.Debug("Telegram photo sent successfully as message {MessageId}", result.MessageId);
+            _log.Debug("Telegram photo sent successfully as message {MessageId}", result.MessageId);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to send a photo from URL {PhotoUrl}", fileUrl);
+            _log.Error(ex, "Telegram. Failed to send a photo from URL {PhotoUrl}", fileUrl);
         }
     }
 
@@ -146,7 +148,7 @@ public class TelegramBot
 
         try
         {
-            Log.Information("Sending Telegram photo from stream ({FileSize} bytes) with caption: {Caption}", 
+            _log.Information("Sending Telegram photo from stream ({FileSize} bytes) with caption: {Caption}", 
                 file.Length, message ?? "(no caption)");
                 
             var result = await _client.SendPhotoAsync(
@@ -155,11 +157,11 @@ public class TelegramBot
                 caption: message
             );
             
-            Log.Debug("Telegram photo from stream sent successfully as message {MessageId}", result.MessageId);
+            _log.Debug("Telegram photo from stream sent successfully as message {MessageId}", result.MessageId);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to send a photo from stream");
+            _log.Error(ex, "Telegram. Failed to send a photo from stream");
         }
     }
 
@@ -167,7 +169,7 @@ public class TelegramBot
     {
         try
         {
-            Log.Information("🗳️ Sending Telegram poll: {Question} with {OptionCount} options", 
+            _log.Information("🗳️ Sending Telegram poll: {Question} with {OptionCount} options", 
                 poll.Question, poll.Options.Count());
                 
             var message = await _client.SendPollAsync(
@@ -176,12 +178,12 @@ public class TelegramBot
                 options: poll.Options.Select(x => x.Text)
             );
 
-            Log.Information("Telegram poll sent successfully as message {MessageId}", message.MessageId);
+            _log.Information("Telegram poll sent successfully as message {MessageId}", message.MessageId);
             return message.MessageId;
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to send a poll with question '{Question}'", poll.Question);
+            _log.Error(ex, "Telegram. Failed to send a poll with question '{Question}'", poll.Question);
             return null;
         }
     }
@@ -190,12 +192,12 @@ public class TelegramBot
     {
         try
         {
-            Log.Information("Stopping Telegram poll with message ID {MessageId}", messageId);
+            _log.Information("Stopping Telegram poll with message ID {MessageId}", messageId);
             var result = await _client.StopPollAsync(_channelId, messageId);
             
             if (result != null)
             {
-                Log.Information("Telegram poll {MessageId} stopped successfully with {VoterCount} total votes", 
+                _log.Information("Telegram poll {MessageId} stopped successfully with {VoterCount} total votes", 
                     messageId, result.TotalVoterCount);
             }
             
@@ -203,7 +205,7 @@ public class TelegramBot
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to stop the poll with message ID {MessageId}", messageId);
+            _log.Error(ex, "Telegram. Failed to stop the poll with message ID {MessageId}", messageId);
             return null;
         }
     }
@@ -212,13 +214,13 @@ public class TelegramBot
     {
         try
         {
-            Log.Debug("Removing Telegram message {MessageId} from chat {ChatId}", messageId, chatId);
+            _log.Debug("Removing Telegram message {MessageId} from chat {ChatId}", messageId, chatId);
             await _client.DeleteMessageAsync(chatId, messageId);
-            Log.Debug("Telegram message {MessageId} removed successfully", messageId);
+            _log.Debug("Telegram message {MessageId} removed successfully", messageId);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Telegram. Failed to remove message {MessageId} from chat {ChatId}", messageId, chatId);
+            _log.Error(ex, "Telegram. Failed to remove message {MessageId} from chat {ChatId}", messageId, chatId);
         }
     }
 

--- a/backend/Veloci.Logic/Bot/Telegram/TelegramBotHostedService.cs
+++ b/backend/Veloci.Logic/Bot/Telegram/TelegramBotHostedService.cs
@@ -6,6 +6,8 @@ namespace Veloci.Logic.Bot.Telegram;
 
 public class TelegramBotHostedService : IHostedService, IDisposable
 {
+    private static readonly ILogger _log = Log.ForContext<TelegramBotHostedService>();
+    
     private TelegramBot _telegramBot;
     private IServiceScope _scope;
 
@@ -19,13 +21,13 @@ public class TelegramBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Information("Bot service TelegramBotHostedService starting...");
+            _log.Information("Bot service TelegramBotHostedService starting...");
             _telegramBot.Init();
-            Log.Information("✅ Bot service TelegramBotHostedService started successfully");
+            _log.Information("✅ Bot service TelegramBotHostedService started successfully");
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Bot service TelegramBotHostedService encountered issues during startup");
+            _log.Error(ex, "Bot service TelegramBotHostedService encountered issues during startup");
             throw;
         }
     }
@@ -34,13 +36,13 @@ public class TelegramBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Information("Bot service TelegramBotHostedService stopping...");
+            _log.Information("Bot service TelegramBotHostedService stopping...");
             _telegramBot.Stop();
-            Log.Information("🛑 Bot service TelegramBotHostedService stopped gracefully");
+            _log.Information("🛑 Bot service TelegramBotHostedService stopped gracefully");
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Bot service TelegramBotHostedService encountered issues during shutdown");
+            _log.Error(ex, "Bot service TelegramBotHostedService encountered issues during shutdown");
             throw;
         }
     }
@@ -49,12 +51,12 @@ public class TelegramBotHostedService : IHostedService, IDisposable
     {
         try
         {
-            Log.Debug("Disposing TelegramBotHostedService resources");
+            _log.Debug("Disposing TelegramBotHostedService resources");
             _scope.Dispose();
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error disposing TelegramBotHostedService resources");
+            _log.Error(ex, "Error disposing TelegramBotHostedService resources");
         }
     }
 }

--- a/backend/Veloci.Logic/Services/Tracks/TrackService.cs
+++ b/backend/Veloci.Logic/Services/Tracks/TrackService.cs
@@ -8,6 +8,8 @@ namespace Veloci.Logic.Services.Tracks;
 
 public class TrackService
 {
+    private static readonly ILogger _log = Log.ForContext<TrackService>();
+    
     private readonly IRepository<Track> _tracks;
     private readonly IRepository<TrackMap> _maps;
     private readonly IRepository<Competition> _competitions;
@@ -28,15 +30,15 @@ public class TrackService
 
     public async Task<Track> GetRandomTrackAsync()
     {
-        Log.Information("🎯 Starting track selection process");
+        _log.Information("🎯 Starting track selection process");
         
         var maps = await _trackFetcher.FetchMapsAsync();
-        Log.Debug("Fetched {MapCount} maps from track fetcher", maps.Count());
+        _log.Debug("Fetched {MapCount} maps from track fetcher", maps.Count());
         
         var filteredTracks = GetCandidateTracks(maps);
         var usedTrackIds = await GetUsedTrackIdsAsync();
         
-        Log.Information("Found {FilteredCount} candidate tracks for 5-inch racing, excluding {UsedTrackCount} recently used tracks", 
+        _log.Information("Found {FilteredCount} candidate tracks for 5-inch racing, excluding {UsedTrackCount} recently used tracks", 
             filteredTracks.Count, usedTrackIds.Count);
 
         var attempts = 0;
@@ -47,12 +49,12 @@ public class TrackService
             var dbTrack = await GetTrackAsync(track.Id)
                           ?? await CreateNewTrackAsync(track.Map.Name, track.Map.Id, track.Name, track.Id);
 
-            Log.Debug("Track selection attempt {Attempt}: Evaluating {TrackName} (ID: {TrackId}) - Rating: {Rating}, Recently used: {RecentlyUsed}", 
+            _log.Debug("Track selection attempt {Attempt}: Evaluating {TrackName} (ID: {TrackId}) - Rating: {Rating}, Recently used: {RecentlyUsed}", 
                 attempts, dbTrack.Name, dbTrack.TrackId, dbTrack.Rating?.Value, usedTrackIds.Contains(dbTrack.Id));
 
             if (dbTrack.Rating?.Value is null or >= 0 && !usedTrackIds.Contains(dbTrack.Id))
             {
-                Log.Information("✅ Selected track {TrackName} (ID: {TrackId}) from {FilteredCount} candidates after {Attempts} attempts", 
+                _log.Information("✅ Selected track {TrackName} (ID: {TrackId}) from {FilteredCount} candidates after {Attempts} attempts", 
                     dbTrack.Name, dbTrack.TrackId, filteredTracks.Count, attempts);
                 return dbTrack;
             }
@@ -62,12 +64,12 @@ public class TrackService
     private List<ParsedTrackModel> GetCandidateTracks(IEnumerable<ParsedMapModel> maps)
     {
         var allTracks = maps.SelectMany(m => m.Tracks).ToList();
-        Log.Debug("Total tracks from all maps: {TrackCount}", allTracks.Count);
+        _log.Debug("Total tracks from all maps: {TrackCount}", allTracks.Count);
         
         var trackFilter = new TrackFilter();
         var filteredTracks = allTracks.Where(t => trackFilter.IsTrackGoodFor5inchRacing(t)).ToList();
         
-        Log.Debug("Filtered to {FilteredCount} tracks suitable for 5-inch racing (from {TotalCount} total)", 
+        _log.Debug("Filtered to {FilteredCount} tracks suitable for 5-inch racing (from {TotalCount} total)", 
             filteredTracks.Count, allTracks.Count);
 
         return filteredTracks;
@@ -82,7 +84,7 @@ public class TrackService
 
     private async Task<Track> CreateNewTrackAsync(string mapName, int mapId, string trackName, int trackId)
     {
-        Log.Debug("Creating new track {TrackName} (ID: {TrackId}) in map {MapName}", trackName, trackId, mapName);
+        _log.Debug("Creating new track {TrackName} (ID: {TrackId}) in map {MapName}", trackName, trackId, mapName);
         
         var dbMap = await _maps
                         .GetAll()
@@ -91,7 +93,7 @@ public class TrackService
 
         if (dbMap.MapId == 0)
         {
-            Log.Debug("Updating map {MapName} with MapId {MapId} (legacy data migration)", mapName, mapId);
+            _log.Debug("Updating map {MapName} with MapId {MapId} (legacy data migration)", mapName, mapId);
             dbMap.MapId = mapId; // since MapId property was added later, some maps dont have this value
         }
 
@@ -103,7 +105,7 @@ public class TrackService
         };
 
         await _tracks.AddAsync(track);
-        Log.Information("✨ Created new track {TrackName} (ID: {TrackId}) in map {MapName}", trackName, trackId, mapName);
+        _log.Information("✨ Created new track {TrackName} (ID: {TrackId}) in map {MapName}", trackName, trackId, mapName);
 
         return track;
     }
@@ -112,12 +114,12 @@ public class TrackService
     {
         if (_usedTrackIds is not null)
         {
-            Log.Debug("Using cached list of {UsedTrackCount} recently used track IDs", _usedTrackIds.Count);
+            _log.Debug("Using cached list of {UsedTrackCount} recently used track IDs", _usedTrackIds.Count);
             return _usedTrackIds;
         }
 
         var start = DateTime.Now.AddMonths(-6);
-        Log.Debug("Querying for tracks used since {StartDate}", start.ToString("yyyy-MM-dd"));
+        _log.Debug("Querying for tracks used since {StartDate}", start.ToString("yyyy-MM-dd"));
 
         var ids = await _competitions
             .GetAll(comp => comp.StartedOn > start)
@@ -125,14 +127,14 @@ public class TrackService
             .ToListAsync();
 
         _usedTrackIds = ids;
-        Log.Debug("Found {UsedTrackCount} tracks used in the last 6 months", ids.Count);
+        _log.Debug("Found {UsedTrackCount} tracks used in the last 6 months", ids.Count);
 
         return ids;
     }
 
     private async Task<TrackMap> CreateNewMapAsync(string name, int mapId)
     {
-        Log.Information("Creating new map {MapName} (ID: {MapId})", name, mapId);
+        _log.Information("Creating new map {MapName} (ID: {MapId})", name, mapId);
         
         var map = new TrackMap
         {
@@ -141,7 +143,7 @@ public class TrackService
         };
 
         await _maps.AddAsync(map);
-        Log.Debug("Successfully created map {MapName}", name);
+        _log.Debug("Successfully created map {MapName}", name);
 
         return map;
     }
@@ -150,7 +152,7 @@ public class TrackService
     {
         var random = new Random();
         var randomIndex = random.Next(0, list.Count);
-        Log.Debug("Selected random element at index {Index} from list of {Count} items", randomIndex, list.Count);
+        _log.Debug("Selected random element at index {Index} from list of {Count} items", randomIndex, list.Count);
         return list[randomIndex];
     }
 }


### PR DESCRIPTION
## Summary
Replace static `Log.*` calls with contextual loggers using `Log.ForContext<T>()` for better log traceability. Each log entry now shows the originating class name making debugging and monitoring more effective.

## Changes
- CompetitionConductor, TelegramBot, DiscordBot, TrackService, CompetitionService
- AchievementService, Velocidrone API client, TelegramCommandProcessor  
- DiscordBotHostedService, TelegramBotHostedService, DiscordMessageEventHandler

Closes #35